### PR TITLE
Feat(platform-detail): passport summary card and shared coordinate fo…

### DIFF
--- a/lib/helpers/coordinate_format.dart
+++ b/lib/helpers/coordinate_format.dart
@@ -1,0 +1,28 @@
+import 'package:latlong2/latlong.dart';
+
+String _formatComponent(
+  double value,
+  String positiveHemisphere,
+  String negativeHemisphere, {
+  int fractionDigits = 3,
+}) {
+  final absolute = value.abs().toStringAsFixed(fractionDigits);
+  final hemisphere = value >= 0 ? positiveHemisphere : negativeHemisphere;
+  return '$absolute°$hemisphere';
+}
+
+/// Formats latitude for operator-facing UI (e.g. `48.290°N`).
+String formatLatitude(double latitude, {int fractionDigits = 3}) {
+  return _formatComponent(latitude, 'N', 'S', fractionDigits: fractionDigits);
+}
+
+/// Formats longitude for operator-facing UI (e.g. `4.968°W`).
+String formatLongitude(double longitude, {int fractionDigits = 3}) {
+  return _formatComponent(longitude, 'E', 'W', fractionDigits: fractionDigits);
+}
+
+/// Formats a [LatLng] for operator-facing UI (e.g. `48.290°N, 4.968°W`).
+String formatLatLng(LatLng point, {int fractionDigits = 3}) {
+  return '${formatLatitude(point.latitude, fractionDigits: fractionDigits)}, '
+      '${formatLongitude(point.longitude, fractionDigits: fractionDigits)}';
+}

--- a/lib/screens/map_screen.dart
+++ b/lib/screens/map_screen.dart
@@ -9,6 +9,7 @@ import 'package:smart_tags/config/map_config.dart';
 import 'package:smart_tags/constants/platform_status_palette.dart';
 import 'package:smart_tags/database/db.dart';
 import 'package:smart_tags/database/mappers/platform_mapper.dart';
+import 'package:smart_tags/helpers/coordinate_format.dart';
 import 'package:smart_tags/helpers/location/location_fetcher.dart';
 import 'package:smart_tags/models/platform.dart' as model;
 import 'package:smart_tags/providers/db_providers.dart';
@@ -326,12 +327,12 @@ class _MapScreenState extends ConsumerState<MapScreen> with TickerProviderStateM
               const SizedBox(height: 12),
               _buildPopupInfoRow(
                 'Latitude',
-                platform.latestPosition.latitude.toStringAsFixed(3),
+                formatLatitude(platform.latestPosition.latitude),
               ),
               const SizedBox(height: 8),
               _buildPopupInfoRow(
                 'Longitude',
-                platform.latestPosition.longitude.toStringAsFixed(3),
+                formatLongitude(platform.latestPosition.longitude),
               ),
               const SizedBox(height: 16),
               SizedBox(
@@ -359,7 +360,6 @@ class _MapScreenState extends ConsumerState<MapScreen> with TickerProviderStateM
   /// Helper method to build a row in the popup info.
   Widget _buildPopupInfoRow(String label, String value) {
     return Row(
-      mainAxisAlignment: MainAxisAlignment.spaceBetween,
       children: [
         Text(
           label,
@@ -367,10 +367,14 @@ class _MapScreenState extends ConsumerState<MapScreen> with TickerProviderStateM
             color: Colors.grey,
           ),
         ),
-        Text(
-          value,
-          style: Theme.of(context).textTheme.bodySmall?.copyWith(
-            fontWeight: FontWeight.w500,
+        const SizedBox(width: 8),
+        Expanded(
+          child: Text(
+            value,
+            textAlign: TextAlign.end,
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+              fontWeight: FontWeight.w500,
+            ),
           ),
         ),
       ],

--- a/lib/screens/platform_detail_screen.dart
+++ b/lib/screens/platform_detail_screen.dart
@@ -236,7 +236,6 @@ class _PlatformSummaryCard extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Row(
-            crossAxisAlignment: CrossAxisAlignment.center,
             children: [
               Expanded(
                 child: Column(

--- a/lib/screens/platform_detail_screen.dart
+++ b/lib/screens/platform_detail_screen.dart
@@ -6,6 +6,7 @@ import 'package:latlong2/latlong.dart';
 import 'package:smart_tags/config/map_config.dart';
 import 'package:smart_tags/constants/platform_status_palette.dart';
 import 'package:smart_tags/database/mappers/platform_mapper.dart';
+import 'package:smart_tags/helpers/coordinate_format.dart';
 import 'package:smart_tags/models/platform.dart';
 import 'package:smart_tags/providers/db_providers.dart';
 import 'package:smart_tags/screens/deploy_platform_screen.dart';
@@ -125,7 +126,7 @@ class _PlatformDetailScreenState extends ConsumerState<PlatformDetailScreen> {
                           borderRadius: BorderRadius.circular(4),
                         ),
                         child: Text(
-                          'Latest position',
+                          'Latest observation',
                           style: Theme.of(context).textTheme.labelSmall?.copyWith(
                             fontWeight: FontWeight.bold,
                           ),
@@ -138,50 +139,7 @@ class _PlatformDetailScreenState extends ConsumerState<PlatformDetailScreen> {
             ),
             const SizedBox(height: 16),
 
-            // Platform Metadata Section
-            SectionContainer(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    platform.model,
-                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                      fontWeight: FontWeight.bold,
-                    ),
-                  ),
-                  Text(
-                    platform.platformRef,
-                    style: Theme.of(context).textTheme.bodySmall,
-                  ),
-                  const Divider(height: 24),
-                  ContainerRow(
-                    label: 'Latest position',
-                    value:
-                        '${platform.latestPosition.latitude.toStringAsFixed(3)}, '
-                        '${platform.latestPosition.longitude.toStringAsFixed(3)}',
-                  ),
-                  const Divider(height: 16),
-                  ContainerRow(
-                    label: 'Network',
-                    value: platform.network,
-                  ),
-                  const Divider(height: 16),
-                  Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        'Status',
-                        style: Theme.of(context).textTheme.labelMedium?.copyWith(
-                          fontWeight: FontWeight.bold,
-                        ),
-                      ),
-                      const SizedBox(height: 4),
-                      StatusBadge.fromStatus(status: platform.status),
-                    ],
-                  ),
-                ],
-              ),
-            ),
+            _PlatformSummaryCard(platform: platform),
             const SizedBox(height: 16),
 
             // Latest Operation Section
@@ -196,22 +154,6 @@ class _PlatformDetailScreenState extends ConsumerState<PlatformDetailScreen> {
                     ),
                   ),
                   const Divider(height: 24),
-                  Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        'Operational Status',
-                        style: Theme.of(context).textTheme.labelMedium?.copyWith(
-                          fontWeight: FontWeight.bold,
-                        ),
-                      ),
-                      const SizedBox(height: 4),
-                      StatusBadge.fromOperationalStatus(
-                        operationalStatus: platform.operationalStatus,
-                      ),
-                    ],
-                  ),
-                  const Divider(height: 16),
                   ContainerRow(
                     label: 'Last updated',
                     value:
@@ -222,9 +164,7 @@ class _PlatformDetailScreenState extends ConsumerState<PlatformDetailScreen> {
                   const Divider(height: 16),
                   ContainerRow(
                     label: 'Position',
-                    value:
-                        '${platform.operationLocation.latitude.toStringAsFixed(3)}, '
-                        '${platform.operationLocation.longitude.toStringAsFixed(3)}',
+                    value: formatLatLng(platform.operationLocation),
                   ),
                   const Divider(height: 16),
                   ContainerRow(
@@ -266,6 +206,88 @@ class _PlatformDetailScreenState extends ConsumerState<PlatformDetailScreen> {
           : const Text('Deploy'),
         ),
       floatingActionButtonLocation: FloatingActionButtonLocation.centerFloat,
+    );
+  }
+}
+
+/// Passport-aligned summary on the platform details page (#97).
+class _PlatformSummaryCard extends StatelessWidget {
+  const _PlatformSummaryCard({required this.platform});
+
+  final Platform platform;
+
+  static String _dash(String? value) {
+    if (value == null || value.trim().isEmpty) {
+      return '-';
+    }
+    final trimmed = value.trim();
+    if (trimmed.toLowerCase() == 'unknown') {
+      return '-';
+    }
+    return trimmed;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return SectionContainer(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      _dash(platform.platformCategory),
+                      style: theme.textTheme.titleLarge?.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      _dash(platform.model),
+                      style: theme.textTheme.titleSmall?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(width: 12),
+              StatusBadge.fromOperationalStatus(
+                operationalStatus: platform.operationalStatus,
+                showLeadingDot: true,
+              ),
+            ],
+          ),
+          const Divider(height: 24),
+          ContainerRow(
+            label: 'WIGOS ID',
+            value: _dash(platform.wigosId),
+          ),
+          const Divider(height: 16),
+          ContainerRow(
+            label: 'Latest observation',
+            value: formatLatLng(platform.latestPosition),
+          ),
+          const Divider(height: 16),
+          ContainerRow(
+            label: 'Last updated',
+            value:
+                '${DateFormat('MMM dd, yyyy, hh:mm a').format(platform.lastUpdated)} UTC',
+          ),
+          const Divider(height: 16),
+          ContainerRow(
+            label: 'Observing network',
+            value: _dash(platform.observingNetwork ?? platform.network),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/widgets/status_badge.dart
+++ b/lib/widgets/status_badge.dart
@@ -7,6 +7,7 @@ class StatusBadge extends StatelessWidget {
   /// Creates a [StatusBadge] from a raw status string.
   const StatusBadge({
     required this.rawStatus,
+    this.showLeadingDot = false,
     super.key,
   })  : status = null,
         operationalStatus = null,
@@ -15,6 +16,7 @@ class StatusBadge extends StatelessWidget {
   /// Creates a [StatusBadge] from a [PlatformStatus] enum value.
   const StatusBadge.fromStatus({
     required this.status,
+    this.showLeadingDot = false,
     super.key,
   })  : rawStatus = null,
         operationalStatus = null,
@@ -23,6 +25,7 @@ class StatusBadge extends StatelessWidget {
   /// Creates a [StatusBadge] from an [OperationalStatus] enum value.
   const StatusBadge.fromOperationalStatus({
     required this.operationalStatus,
+    this.showLeadingDot = false,
     super.key,
   })  : rawStatus = null,
         status = null,
@@ -31,6 +34,7 @@ class StatusBadge extends StatelessWidget {
   /// Creates a [StatusBadge] with an explicit [PlatformStatusStyle].
   const StatusBadge.fromStyle({
     required PlatformStatusStyle this.style,
+    this.showLeadingDot = false,
     super.key,
   })  : rawStatus = null,
         status = null,
@@ -47,6 +51,9 @@ class StatusBadge extends StatelessWidget {
 
   /// Explicit style when constructed via [StatusBadge.fromStyle].
   final PlatformStatusStyle? style;
+
+  /// When true, shows a dot before the label (passport summary mock).
+  final bool showLeadingDot;
 
   PlatformStatusStyle _resolveStyle() {
     final explicitStyle = style;
@@ -72,17 +79,33 @@ class StatusBadge extends StatelessWidget {
     final badgeStyle = _resolveStyle();
 
     return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
       decoration: BoxDecoration(
         color: badgeStyle.backgroundColor,
-        borderRadius: BorderRadius.circular(12),
+        borderRadius: BorderRadius.circular(20),
       ),
-      child: Text(
-        badgeStyle.label,
-        style: Theme.of(context).textTheme.labelMedium?.copyWith(
-          color: badgeStyle.textColor,
-          fontWeight: FontWeight.w600,
-        ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (showLeadingDot) ...[
+            Container(
+              width: 8,
+              height: 8,
+              decoration: BoxDecoration(
+                color: badgeStyle.textColor,
+                shape: BoxShape.circle,
+              ),
+            ),
+            const SizedBox(width: 6),
+          ],
+          Text(
+            badgeStyle.label,
+            style: Theme.of(context).textTheme.labelMedium?.copyWith(
+              color: badgeStyle.textColor,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/test/helpers/coordinate_format_test.dart
+++ b/test/helpers/coordinate_format_test.dart
@@ -1,0 +1,21 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:smart_tags/helpers/coordinate_format.dart';
+
+void main() {
+  test('formatLatLng uses hemisphere suffixes', () {
+    expect(
+      formatLatLng(const LatLng(48.29, -4.968)),
+      '48.290°N, 4.968°W',
+    );
+    expect(
+      formatLatLng(const LatLng(-33.815, 149.765)),
+      '33.815°S, 149.765°E',
+    );
+  });
+
+  test('formatLatitude and formatLongitude', () {
+    expect(formatLatitude(45.5), '45.500°N');
+    expect(formatLongitude(-5.5), '5.500°W');
+  });
+}

--- a/test/qr_scan_test.dart
+++ b/test/qr_scan_test.dart
@@ -118,7 +118,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byType(PlatformDetailScreen), findsOneWidget);
-    expect(find.text(mockPlatformRef), findsOneWidget);
+    expect(find.text('Model A'), findsOneWidget);
 
     await tester.pumpWidget(const SizedBox.shrink());
     // Allow the widget tree to process disposal and cancel streams.

--- a/test/screens/map_screen_test.dart
+++ b/test/screens/map_screen_test.dart
@@ -193,8 +193,8 @@ void main() {
       expect(find.text('ID: TEST-001'), findsOneWidget);
       expect(find.text('Latitude'), findsOneWidget);
       expect(find.text('Longitude'), findsOneWidget);
-      expect(find.text('45.500'), findsOneWidget);
-      expect(find.text('-5.500'), findsOneWidget);
+      expect(find.text('45.500°N'), findsOneWidget);
+      expect(find.text('5.500°W'), findsOneWidget);
 
       await tester.pumpWidget(const SizedBox.shrink());
       await tester.pump(const Duration(milliseconds: 100));
@@ -244,8 +244,8 @@ void main() {
       }
 
       // Verify the popup displays the correct latitude and longitude
-      expect(find.text('51.234'), findsOneWidget);
-      expect(find.text('-10.567'), findsOneWidget);
+      expect(find.text('51.234°N'), findsOneWidget);
+      expect(find.text('10.567°W'), findsOneWidget);
 
       await tester.pumpWidget(const SizedBox.shrink());
       await tester.pump(const Duration(milliseconds: 100));

--- a/test/screens/platform_detail_screen_test.dart
+++ b/test/screens/platform_detail_screen_test.dart
@@ -14,22 +14,40 @@ final testDbPlatform = Platform(
   ref: testRef,
   model: 'Model 1',
   network: 'Network 1',
-  lat: 0,
-  lon: 0,
+  lat: 12.345,
+  lon: 67.89,
   status: 'OPERATIONAL',
   operationalStatus: 'Deployed',
-  lastUpdated: DateTime(2025),
+  lastUpdated: DateTime.utc(2025, 6, 8, 23, 54, 33),
   operationLat: 0,
   operationLon: 0,
 );
 
+final testDbPlatformPassport = Platform(
+  id: 1,
+  ref: testRef,
+  model: 'PROVOR_MT',
+  network: 'Argo',
+  lat: 33.815,
+  lon: 149.765,
+  status: 'OPERATIONAL',
+  operationalStatus: 'Deployed',
+  lastUpdated: DateTime.utc(2002, 6, 8, 23, 54, 33),
+  operationLat: 33.999,
+  operationLon: 143.993,
+  platformCategory: 'Float',
+  wigosId: '2900314',
+  observingNetwork: 'Argo',
+);
+
 /// Builds a [ProviderScope] with [platformByRefStreamProvider] overridden
 /// to return [testDbPlatform] without hitting a real database.
-Widget buildTestWidget() {
+Widget buildTestWidget({Platform? platform}) {
+  final row = platform ?? testDbPlatform;
   return ProviderScope(
     overrides: [
       platformByRefStreamProvider(testRef).overrideWith(
-        (ref) => Stream.value(testDbPlatform),
+        (ref) => Stream.value(row),
       ),
     ],
     child: const MaterialApp(
@@ -61,5 +79,28 @@ void main() {
     await tester.pumpWidget(buildTestWidget());
     await tester.pump();
     expect(find.byIcon(Icons.arrow_back), findsOneWidget);
+  });
+
+  testWidgets('Platform summary shows passport metadata (#97)', (tester) async {
+    await tester.pumpWidget(buildTestWidget(platform: testDbPlatformPassport));
+    await tester.pump();
+
+    expect(find.text('Float'), findsOneWidget);
+    expect(find.text('PROVOR_MT'), findsOneWidget);
+    expect(find.text('WIGOS ID'), findsOneWidget);
+    expect(find.text('2900314'), findsOneWidget);
+    expect(find.text('Latest observation'), findsWidgets);
+    expect(find.text('33.815°N, 149.765°E'), findsOneWidget);
+    expect(find.text('Observing network'), findsOneWidget);
+    expect(find.text('Argo'), findsOneWidget);
+    expect(find.text('Deployed'), findsOneWidget);
+  });
+
+  testWidgets('Platform summary shows dash for missing passport fields (#97)', (tester) async {
+    await tester.pumpWidget(buildTestWidget());
+    await tester.pump();
+
+    expect(find.text('WIGOS ID'), findsOneWidget);
+    expect(find.text('-'), findsWidgets);
   });
 }


### PR DESCRIPTION
### **Before:**

<img width="564" height="957" alt="Image" src="https://github.com/user-attachments/assets/4490ff41-de9e-4c75-8f31-b4b1f645a952" />

<img width="375" height="383" alt="Image" src="https://github.com/user-attachments/assets/947703a7-c25e-4bf2-a186-2f59807a9a76" />

### **After:**

<img width="379" height="788" alt="Image" src="https://github.com/user-attachments/assets/bbf02f8d-cbb8-486a-946e-7ec2a4301fdd" />

<img width="392" height="338" alt="Image" src="https://github.com/user-attachments/assets/3e08e81f-5aa2-4694-9913-b076f346c635" />

### **_What has been done:_**

### Platform details summary card
- First card aligned with passport spec: category (title), model (subtitle), operational status chip (top right, centered, with dot, as same as the maquette), WIGOS ID, latest observation, last updated, observing network. Edge case handled: missing values show –
- position uses the same coordinate format; duplicate operational status removed from that block
### Coordinates
- Created an helper function in `lib/helpers/coordinate_format.dart` + display all the coordinates with degrees, in map marker, platform details card 1 and 2 
### Status Badge
- Optional `showLeadingDot` on `StatusBadge`


+ Tests updated